### PR TITLE
Fix bug in 77: 解决tailwindcss默认的是rem，rem不会转换为vmin的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "mockjs": "^1.1.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.47",
+    "postcss-rem-to-pixel": "^4.1.2",
     "prettier": "^3.3.3",
     "standard-version": "^9.5.0",
     "tailwindcss": "^3.4.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.4.47
+      postcss-rem-to-pixel:
+        specifier: ^4.1.2
+        version: 4.1.2
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -2924,6 +2927,9 @@ packages:
     resolution: {integrity: sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==}
     peerDependencies:
       postcss: '>4 <9'
+
+  postcss-rem-to-pixel@4.1.2:
+    resolution: {integrity: sha512-EaA1Ak5SxmT31KA1clM4jRcEXQQ7oceXM2WF59fJw/mhspn1fhm202ZIfto5qFCX4QVuk/WVvATfkWaIlMomSw==}
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -6694,6 +6700,11 @@ snapshots:
 
   postcss-prefix-selector@1.16.1(postcss@5.2.18):
     dependencies:
+      postcss: 5.2.18
+
+  postcss-rem-to-pixel@4.1.2:
+    dependencies:
+      object-assign: 4.1.1
       postcss: 5.2.18
 
   postcss-selector-parser@6.1.2:

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,11 @@
 export default {
   plugins: {
     tailwindcss: {},
+    // 解决tailwindcss默认的是rem，rem不会转换为vmin的问题
+    "postcss-rem-to-pixel": {
+      rootValue: 16, // 根元素字体大小（默认 16px）
+      propList: ["*"] // 转换所有属性的 rem 单位
+    },
     // 使用 cnjm-postcss-px-to-viewport 规避 postcss.plugin was deprecated 警告
     "cnjm-postcss-px-to-viewport": {
       viewportWidth: 375, // 根据设计稿设定


### PR DESCRIPTION
解决issues #77 